### PR TITLE
docs: update Slack link and minor typos

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Thank you for contributing to Ocular!
 
 ## Getting Started
 
-For help setting up the code in this repo, please follow our [DEVELOPERS.md](https://github.com/OcularEngineering/ocular/blob/main/CONTRIBUTING.md) file.
+For help setting up the code in this repo, please follow our [DEVELOPERS.md](https://github.com/OcularEngineering/ocular/blob/main/DEVELOPERS.md) file.
 
 ## Issues
 
@@ -21,4 +21,4 @@ We actively welcome your Pull Requests!
 
 Reach out on Slack for further assistance.
 
-- [slack](https://slack.com)
+- [Slack](https://join.slack.com/t/ocular-ai/shared_invite/zt-2g7ka0j1c-Tx~Q46MjplNma2Sk2Ruplw)

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -143,4 +143,4 @@ We don't have a process for assigning issues to contributors yet.
 
 ## Community channels
 
-If you get stuck somewhere or have any questions, join our [Discord Community Server](https://slack.com)!
+If you get stuck somewhere or have any questions, join our [Slack Workspace](https://join.slack.com/t/ocular-ai/shared_invite/zt-2g7ka0j1c-Tx~Q46MjplNma2Sk2Ruplw)!

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,7 @@
 
 Contact: engineering@useocular.com
 
-Ocular considers the securitu of systems a top priority. 
+Ocular considers the security of systems a top priority. 
 
 If you discover a vulnerability, we would like to know about it so we can take steps to address it as quickly as possible. We would like to ask you to help us better protect our users and our systems.
 


### PR DESCRIPTION
I am setting up the project and had been going through the docs. Found some minor issues regarding Slack Link and fixed minor typos across markdown files