### PR TITLE
skeleton scroll fix

### DIFF
--- a/packages/ocular-ui/tailwind.config.js
+++ b/packages/ocular-ui/tailwind.config.js
@@ -80,6 +80,11 @@ module.exports = {
       flexGrow: {
         '3': '3',
       },
+      zIndex: {
+        '100': 100,
+        '500': 500,
+        '1000': 1000,
+      },
     },
   },
   plugins: [require("tailwindcss-animate")],


### PR DESCRIPTION
# Description 📣
Skeleton scroll issue fix. 

Added custom z-index values in tailwind.config.js for z-100, z-500 and z-1000.

By default, Tailwind offers a limited range of predefined z-index values (`z-0 to z-50`).
`header.tsx` uses `z-1000` which was needed to be defined.

## Type 

- Bug fix

## Code block

```sh
// tailwind.config.js
zIndex: {
        '100': 100,
        '500': 500,
        '1000': 1000,
      },
```
---

- I have read the [contributing guide](https://github.com/OcularEngineering/ocular/blob/main/CONTRIBUTING.md).

